### PR TITLE
Add CLI and Docker setup for keiba analytics workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.sqlite3
+*.db
+.env
+.git

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "-m", "keiba.cli"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,110 @@
 # python_keiba
+
+競馬データを蓄積し、過去の傾向から購入すべき馬券を分析するためのローカル実行向けツールです。Mac 上でそのまま実行することも、Docker コンテナを用いて環境を固定することもできます。
+
+## データファイルのフォーマット
+
+本ツールは以下のカラムを持つ CSV ファイルを想定しています。1 行が 1 頭の出走馬に対応し、同じ `race_id` の行が 1 つのレースを構成します。
+
+| カラム名 | 説明 |
+| --- | --- |
+| `race_id` | レースを一意に識別する ID（文字列） |
+| `date` | レース開催日（例: `2024-05-26`） |
+| `racecourse` | 競馬場名 |
+| `distance` | 距離 (m) |
+| `track_condition` | 馬場状態（良 / 稍重 / 重 / 不良 等） |
+| `num_runners` | 出走頭数 |
+| `track_direction` | コースの回り（左 / 右 等） |
+| `weather` | 天候 |
+| `horse_number` | 馬番 |
+| `horse_name` | 馬名 |
+| `popularity` | 人気順（1 が最も人気） |
+| `finish_position` | 着順（数値。1 が 1 着） |
+| `odds_win` | 単勝オッズ |
+| `odds_place` | 複勝オッズ |
+| `return_win` | 単勝 100 円購入時の払戻金（外れた場合は 0） |
+| `return_place` | 複勝 100 円購入時の払戻金（外れた場合は 0） |
+
+## ローカル環境での使い方
+
+1. Python 3.11 以上をインストールします。
+2. リポジトリ直下で依存関係をセットアップします（現時点では追加ライブラリはありませんが、
+   環境構築手順を統一するため `requirements.txt` をインストールする手順を残しています）。
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+
+3. データベースを初期化します。
+
+   ```bash
+   python -m keiba.cli init-db --db-path keiba.db
+   ```
+
+4. CSV を取り込んでデータを蓄積します。
+
+   ```bash
+   python -m keiba.cli ingest data/races_2024.csv --db-path keiba.db
+   ```
+
+5. 購入シミュレーションを実行します。`--horse-popularities` は出走予定馬の人気順を入力します（例: 1,2,4,6,...）。
+
+   ```bash
+   python -m keiba.cli suggest \
+       --racecourse "東京" \
+       --distance 2400 \
+       --track-condition "良" \
+       --num-runners 18 \
+       --track-direction "左" \
+       --weather "晴" \
+       --horse-popularities 1 --horse-popularities 2 --horse-popularities 4 \
+       --horse-popularities 5 --horse-popularities 7 --horse-popularities 8 \
+       --horse-popularities 9 --horse-popularities 10 --horse-popularities 12 \
+       --horse-popularities 13 --db-path keiba.db
+   ```
+
+   デフォルトでは予算 1 万円を 10 点に均等配分します。`--budget` と `--num-tickets` オプションで変更できます。
+
+## Docker での実行
+
+1. イメージをビルドします。
+
+   ```bash
+   docker build -t keiba-analytics .
+   ```
+
+2. CSV を取り込む場合は、ホスト側のファイルを `/data` などにマウントして実行します。
+
+   ```bash
+   docker run --rm -v $(pwd)/data:/data -v $(pwd)/storage:/storage \
+       keiba-analytics init-db --db-path /storage/keiba.db
+
+   docker run --rm -v $(pwd)/data:/data -v $(pwd)/storage:/storage \
+       keiba-analytics ingest /data/races_2024.csv --db-path /storage/keiba.db
+   ```
+
+3. 予想を出す場合も同様に実行します。
+
+   ```bash
+   docker run --rm -v $(pwd)/storage:/storage keiba-analytics suggest \
+       --racecourse "東京" --distance 2400 --track-condition "良" \
+       --num-runners 18 --track-direction "左" --weather "晴" \
+       --horse-popularities 1 --horse-popularities 2 --horse-popularities 3 \
+       --horse-popularities 5 --horse-popularities 6 --horse-popularities 7 \
+       --horse-popularities 8 --horse-popularities 9 --horse-popularities 10 \
+       --horse-popularities 12 --db-path /storage/keiba.db
+   ```
+
+   `storage` ディレクトリに SQLite データベースが保存されるので、コンテナを破棄してもデータが保持されます。
+
+## 推奨ワークフロー
+
+1. ローカルで日々のレース結果を CSV にエクスポートして `data/` 以下に保存する。
+2. `ingest` コマンドで定期的に取り込むことでデータベースを更新する。
+3. レース条件と想定人気を入力して `suggest` を実行し、期待値が高い組み合わせを抽出する。
+
+将来的には機械学習モデルやより高度な指標を組み込むことも可能です。その際も SQLite にデータが蓄積されていれば柔軟に分析を追加できます。
+

--- a/keiba/__init__.py
+++ b/keiba/__init__.py
@@ -1,0 +1,11 @@
+"""Keiba analytics package."""
+
+from .analysis import recommend_bets
+from .data_loader import ingest_csv
+from .database import initialize_database
+
+__all__ = [
+    "recommend_bets",
+    "ingest_csv",
+    "initialize_database",
+]

--- a/keiba/analysis.py
+++ b/keiba/analysis.py
@@ -1,0 +1,179 @@
+"""Analytical helpers for horse racing wagers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean
+from typing import Dict, List, Optional, Sequence
+
+from .database import DB_PATH_DEFAULT, get_connection
+
+
+@dataclass
+class BetRecommendation:
+    """Structured representation of a suggested bet."""
+
+    horse_label: str
+    popularity_rank: int
+    expected_return_per_ticket: float
+    suggested_bet_amount: float
+
+
+def _build_filters(
+    *,
+    racecourse: Optional[str],
+    distance: Optional[int],
+    track_condition: Optional[str],
+    num_runners: Optional[int],
+    track_direction: Optional[str],
+    weather: Optional[str],
+) -> tuple[str, List[object]]:
+    clauses = ["WHERE 1=1"]
+    params: List[object] = []
+
+    def add(column: str, value: Optional[object]) -> None:
+        if value is None:
+            return
+        clauses.append(f"AND r.{column} = ?")
+        params.append(value)
+
+    add("racecourse", racecourse)
+    add("distance", distance)
+    add("track_condition", track_condition)
+    add("num_runners", num_runners)
+    add("track_direction", track_direction)
+    add("weather", weather)
+
+    return "\n".join(clauses), params
+
+
+def _fetch_popularity_metrics(
+    db_path: Path | str | None,
+    *,
+    racecourse: Optional[str] = None,
+    distance: Optional[int] = None,
+    track_condition: Optional[str] = None,
+    num_runners: Optional[int] = None,
+    track_direction: Optional[str] = None,
+    weather: Optional[str] = None,
+) -> List[Dict[str, float]]:
+    where_clause, params = _build_filters(
+        racecourse=racecourse,
+        distance=distance,
+        track_condition=track_condition,
+        num_runners=num_runners,
+        track_direction=track_direction,
+        weather=weather,
+    )
+
+    query = f"""
+        SELECT
+            e.popularity AS popularity,
+            COUNT(*) AS bets,
+            COUNT(DISTINCT e.race_id) AS races,
+            SUM(CASE WHEN e.finish_position = 1 THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS win_rate,
+            AVG(e.return_win) AS avg_return
+        FROM race_entries e
+        JOIN races r ON r.race_id = e.race_id
+        {where_clause}
+        GROUP BY e.popularity
+        ORDER BY avg_return DESC
+    """
+
+    with get_connection(db_path) as conn:
+        rows = conn.execute(query, params).fetchall()
+
+    if not rows:
+        raise ValueError(
+            "No historical entries match the provided race filters. "
+            "Ingest more data or relax the conditions."
+        )
+
+    metrics = []
+    for row in rows:
+        avg_return = float(row["avg_return"] or 0.0)
+        metrics.append(
+            {
+                "popularity": int(row["popularity"]),
+                "bets": float(row["bets"]),
+                "races": float(row["races"]),
+                "win_rate": float(row["win_rate"] or 0.0),
+                "avg_return": avg_return,
+                "expected_return_per_100yen": avg_return - 100.0,
+            }
+        )
+
+    return metrics
+
+
+def recommend_bets(
+    *,
+    db_path: Path | str | None = None,
+    racecourse: Optional[str] = None,
+    distance: Optional[int] = None,
+    track_condition: Optional[str] = None,
+    num_runners: Optional[int] = None,
+    track_direction: Optional[str] = None,
+    weather: Optional[str] = None,
+    horse_popularities: Sequence[int],
+    budget: int = 10_000,
+    num_tickets: int = 10,
+) -> List[BetRecommendation]:
+    """Recommend wagers for an upcoming race."""
+
+    if num_tickets <= 0:
+        raise ValueError("num_tickets must be positive")
+    if budget <= 0:
+        raise ValueError("budget must be positive")
+    if len(horse_popularities) < num_tickets:
+        raise ValueError("Provide at least as many horses as tickets you plan to buy")
+
+    metrics = _fetch_popularity_metrics(
+        db_path,
+        racecourse=racecourse,
+        distance=distance,
+        track_condition=track_condition,
+        num_runners=num_runners,
+        track_direction=track_direction,
+        weather=weather,
+    )
+
+    mean_expected = fmean(m["expected_return_per_100yen"] for m in metrics)
+    ticket_value = budget / num_tickets
+
+    popularity_to_metric = {m["popularity"]: m for m in metrics}
+
+    upcoming = []
+    for idx, popularity in enumerate(horse_popularities, start=1):
+        metric = popularity_to_metric.get(popularity)
+        if metric is None:
+            expected_bonus = mean_expected
+            avg_return = 100.0 + expected_bonus
+        else:
+            expected_bonus = metric["expected_return_per_100yen"]
+            avg_return = metric["avg_return"]
+        expected_total = (avg_return / 100.0) * ticket_value
+        upcoming.append(
+            {
+                "horse_label": f"Horse #{idx}",
+                "popularity": popularity,
+                "expected": expected_bonus,
+                "expected_total": expected_total,
+            }
+        )
+
+    ranked = sorted(upcoming, key=lambda item: item["expected"], reverse=True)
+
+    recommendations = [
+        BetRecommendation(
+            horse_label=item["horse_label"],
+            popularity_rank=item["popularity"],
+            expected_return_per_ticket=item["expected_total"],
+            suggested_bet_amount=ticket_value,
+        )
+        for item in ranked[:num_tickets]
+    ]
+
+    return recommendations
+

--- a/keiba/cli.py
+++ b/keiba/cli.py
@@ -1,0 +1,89 @@
+"""Command line interface for the keiba analytics tools."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List, Optional
+
+from .analysis import recommend_bets
+from .data_loader import DataValidationError, ingest_csv
+from .database import DB_PATH_DEFAULT, initialize_database
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Utilities to manage keiba race data")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init-db", help="Initialise the SQLite database")
+    init_parser.add_argument("--db-path", type=Path, default=None, help="Path to the SQLite database")
+
+    ingest_parser = subparsers.add_parser("ingest", help="Load a CSV file into the database")
+    ingest_parser.add_argument("csv_path", type=Path, help="Path to the CSV file")
+    ingest_parser.add_argument("--db-path", type=Path, default=None, help="Path to the SQLite database")
+
+    suggest_parser = subparsers.add_parser("suggest", help="Generate bet recommendations")
+    suggest_parser.add_argument("--racecourse", type=str, default=None)
+    suggest_parser.add_argument("--distance", type=int, default=None)
+    suggest_parser.add_argument("--track-condition", dest="track_condition", type=str, default=None)
+    suggest_parser.add_argument("--num-runners", dest="num_runners", type=int, default=None)
+    suggest_parser.add_argument("--track-direction", dest="track_direction", type=str, default=None)
+    suggest_parser.add_argument("--weather", type=str, default=None)
+    suggest_parser.add_argument(
+        "--horse-popularities",
+        dest="horse_popularities",
+        type=int,
+        nargs="+",
+        required=True,
+        help="Popularity ranks for the upcoming race",
+    )
+    suggest_parser.add_argument("--budget", type=int, default=10_000, help="Total budget in yen")
+    suggest_parser.add_argument("--num-tickets", dest="num_tickets", type=int, default=10, help="Number of tickets to buy")
+    suggest_parser.add_argument("--db-path", type=Path, default=None, help="Path to the SQLite database")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    if args.command == "init-db":
+        initialize_database(args.db_path)
+        print(f"Database initialised at {args.db_path or DB_PATH_DEFAULT}")
+        return 0
+
+    if args.command == "ingest":
+        try:
+            races, entries = ingest_csv(args.csv_path, db_path=args.db_path)
+        except DataValidationError as exc:
+            print(f"Validation failed: {exc}")
+            return 1
+        print(f"Imported {races} races and {entries} race entries.")
+        return 0
+
+    if args.command == "suggest":
+        recommendations = recommend_bets(
+            db_path=args.db_path,
+            racecourse=args.racecourse,
+            distance=args.distance,
+            track_condition=args.track_condition,
+            num_runners=args.num_runners,
+            track_direction=args.track_direction,
+            weather=args.weather,
+            horse_popularities=args.horse_popularities,
+            budget=args.budget,
+            num_tickets=args.num_tickets,
+        )
+        for rec in recommendations:
+            print(
+                f"{rec.horse_label} (popularity {rec.popularity_rank}): "
+                f"bet {rec.suggested_bet_amount:.0f}円 -> expected return {rec.expected_return_per_ticket:.0f}円"
+            )
+        return 0
+
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/keiba/data_loader.py
+++ b/keiba/data_loader.py
@@ -1,0 +1,131 @@
+"""Utilities to load raw CSV files into the database."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from .database import DB_PATH_DEFAULT, bulk_insert, get_connection, initialize_database
+
+REQUIRED_COLUMNS = {
+    "race_id",
+    "date",
+    "racecourse",
+    "distance",
+    "track_condition",
+    "num_runners",
+    "track_direction",
+    "weather",
+    "horse_number",
+    "horse_name",
+    "popularity",
+    "finish_position",
+    "odds_win",
+    "odds_place",
+    "return_win",
+    "return_place",
+}
+
+
+class DataValidationError(Exception):
+    """Raised when the ingested data does not match expectations."""
+
+
+def _validate_columns(columns: Iterable[str]) -> None:
+    missing = REQUIRED_COLUMNS.difference(columns)
+    if missing:
+        joined = ", ".join(sorted(missing))
+        raise DataValidationError(f"CSV is missing required columns: {joined}")
+
+
+def _cast_int(record: Dict[str, str], key: str) -> int:
+    try:
+        return int(record[key])
+    except (KeyError, ValueError) as exc:
+        raise DataValidationError(f"Column '{key}' must contain integers") from exc
+
+
+def _cast_float(record: Dict[str, str], key: str) -> float:
+    try:
+        return float(record[key])
+    except (KeyError, ValueError) as exc:
+        raise DataValidationError(f"Column '{key}' must contain numbers") from exc
+
+
+def ingest_csv(csv_path: Path | str, db_path: Path | str | None = None) -> Tuple[int, int]:
+    """Load a CSV file into the SQLite database."""
+
+    csv_path = Path(csv_path)
+    db_path = Path(db_path) if db_path else DB_PATH_DEFAULT
+
+    if not csv_path.exists():
+        raise FileNotFoundError(csv_path)
+
+    initialize_database(db_path)
+
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise DataValidationError("CSV file does not contain headers")
+        _validate_columns(reader.fieldnames)
+
+        race_records: Dict[str, Dict[str, object]] = {}
+        entry_records: List[Dict[str, object]] = []
+
+        for row in reader:
+            race_id = row["race_id"].strip()
+            race_records[race_id] = {
+                "race_id": race_id,
+                "date": row["date"].strip(),
+                "racecourse": row["racecourse"].strip(),
+                "distance": _cast_int(row, "distance"),
+                "track_condition": row["track_condition"].strip(),
+                "num_runners": _cast_int(row, "num_runners"),
+                "track_direction": row["track_direction"].strip(),
+                "weather": row["weather"].strip(),
+            }
+            entry_records.append(
+                {
+                    "race_id": race_id,
+                    "horse_number": _cast_int(row, "horse_number"),
+                    "horse_name": row["horse_name"].strip(),
+                    "popularity": _cast_int(row, "popularity"),
+                    "finish_position": _cast_int(row, "finish_position"),
+                    "odds_win": _cast_float(row, "odds_win"),
+                    "odds_place": _cast_float(row, "odds_place"),
+                    "return_win": _cast_float(row, "return_win"),
+                    "return_place": _cast_float(row, "return_place"),
+                }
+            )
+
+    with get_connection(db_path) as conn:
+        bulk_insert(
+            conn,
+            """
+            INSERT OR REPLACE INTO races (
+                race_id, date, racecourse, distance, track_condition,
+                num_runners, track_direction, weather
+            ) VALUES (
+                :race_id, :date, :racecourse, :distance, :track_condition,
+                :num_runners, :track_direction, :weather
+            );
+            """,
+            race_records.values(),
+        )
+        bulk_insert(
+            conn,
+            """
+            INSERT OR REPLACE INTO race_entries (
+                race_id, horse_number, horse_name, popularity, finish_position,
+                odds_win, odds_place, return_win, return_place
+            ) VALUES (
+                :race_id, :horse_number, :horse_name, :popularity, :finish_position,
+                :odds_win, :odds_place, :return_win, :return_place
+            );
+            """,
+            entry_records,
+        )
+
+    return len(race_records), len(entry_records)
+

--- a/keiba/database.py
+++ b/keiba/database.py
@@ -1,0 +1,82 @@
+"""Database utilities for the keiba analytics package."""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator, Iterable, Mapping, Sequence
+
+DB_PATH_DEFAULT = Path("keiba.db")
+
+
+@contextmanager
+def get_connection(db_path: Path | str | None = None) -> Generator[sqlite3.Connection, None, None]:
+    """Context manager that yields an SQLite connection.
+
+    Parameters
+    ----------
+    db_path:
+        Optional path to the SQLite database. When omitted, ``keiba.db`` in the
+        current working directory is used.
+    """
+
+    path = Path(db_path) if db_path else DB_PATH_DEFAULT
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.row_factory = sqlite3.Row
+        yield conn
+    finally:
+        conn.commit()
+        conn.close()
+
+
+def initialize_database(db_path: Path | str | None = None) -> None:
+    """Create database tables if they do not already exist."""
+
+    with get_connection(db_path) as conn:
+        cursor = conn.cursor()
+        cursor.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS races (
+                race_id TEXT PRIMARY KEY,
+                date TEXT,
+                racecourse TEXT,
+                distance INTEGER,
+                track_condition TEXT,
+                num_runners INTEGER,
+                track_direction TEXT,
+                weather TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS race_entries (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                race_id TEXT NOT NULL,
+                horse_number INTEGER,
+                horse_name TEXT,
+                popularity INTEGER,
+                finish_position INTEGER,
+                odds_win REAL,
+                odds_place REAL,
+                return_win REAL,
+                return_place REAL,
+                FOREIGN KEY (race_id) REFERENCES races(race_id)
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_entries_race_horse
+            ON race_entries (race_id, horse_number);
+            """
+        )
+
+
+def bulk_insert(
+    conn: sqlite3.Connection,
+    query: str,
+    rows: Iterable[Sequence | Mapping],
+) -> None:
+    """Execute a parameterized insert for many rows."""
+
+    cursor = conn.cursor()
+    cursor.executemany(query, rows)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# This project currently uses only the Python standard library.


### PR DESCRIPTION
## Summary
- add a lightweight `keiba` package with SQLite schema helpers, CSV ingestion, and betting recommendation logic
- provide an argparse-based CLI covering database initialization, CSV import, and suggestion generation
- document local and Docker usage and include container build assets and ignore rules

## Testing
- python -m keiba.cli --help
- python -m keiba.cli suggest --help
- python -m keiba.cli init-db --db-path test.db


------
https://chatgpt.com/codex/tasks/task_e_68e1aabdb7408327a04d29f7981761a0