### PR TITLE
Add trifecta combination suggestions to purchase simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ CSV のカラム定義は以下の通りです。
    ```
 
 5. 購入シミュレーションを実行します。`--horse-popularities` は出走予定馬の人気順を入力します（例: 1,2,4,6,...）。
+   過去の傾向から三連複（3 頭の組み合わせ）として期待値が高い 10 点を提案します。
 
    ```bash
    python -m keiba.cli suggest \
@@ -111,6 +112,13 @@ CSV のカラム定義は以下の通りです。
    ```
 
    デフォルトでは予算 1 万円を 10 点に均等配分します。`--budget` と `--num-tickets` オプションで変更できます。
+   出力例:
+
+   ```
+   Combination 1-2-4: bet 1000円, hit rate 8.5% -> expected return 920円
+   Combination 1-3-4: bet 1000円, hit rate 7.9% -> expected return 910円
+   ...
+   ```
 
 ## Docker での実行
 

--- a/keiba/analysis.py
+++ b/keiba/analysis.py
@@ -3,21 +3,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import combinations
 from pathlib import Path
 from statistics import fmean
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from .database import DB_PATH_DEFAULT, get_connection
 
 
 @dataclass
 class BetRecommendation:
-    """Structured representation of a suggested bet."""
+    """Structured representation of a suggested trio (三連複) bet."""
 
-    horse_label: str
-    popularity_rank: int
+    combination: Tuple[int, int, int]
+    hit_rate: float
+    estimated_average_payout: float
     expected_return_per_ticket: float
     suggested_bet_amount: float
+
+    @property
+    def combination_label(self) -> str:
+        """Return a human readable label such as ``1-2-4``."""
+
+        return "-".join(str(popularity) for popularity in self.combination)
 
 
 def _build_filters(
@@ -48,7 +56,7 @@ def _build_filters(
     return "\n".join(clauses), params
 
 
-def _fetch_popularity_metrics(
+def _fetch_trifecta_statistics(
     db_path: Path | str | None,
     *,
     racecourse: Optional[str] = None,
@@ -57,7 +65,15 @@ def _fetch_popularity_metrics(
     num_runners: Optional[int] = None,
     track_direction: Optional[str] = None,
     weather: Optional[str] = None,
-) -> List[Dict[str, float]]:
+) -> Tuple[int, Dict[Tuple[int, int, int], Dict[str, float]]]:
+    """Return hit counts and payout aggregates for 三連複 combinations.
+
+    The SQLite schema does not store actual 三連複払戻金. 代わりに、1 着馬の
+    単勝払戻しと上位 3 頭の複勝払戻しを合算したものを近似的な平均配当と
+    して扱う。実際の三連複配当はこれより高くなることが多いため、安全側の
+    推定として利用できる。
+    """
+
     where_clause, params = _build_filters(
         racecourse=racecourse,
         distance=distance,
@@ -69,16 +85,16 @@ def _fetch_popularity_metrics(
 
     query = f"""
         SELECT
-            e.popularity AS popularity,
-            COUNT(*) AS bets,
-            COUNT(DISTINCT e.race_id) AS races,
-            SUM(CASE WHEN e.finish_position = 1 THEN 1 ELSE 0 END) * 1.0 / COUNT(*) AS win_rate,
-            AVG(e.return_win) AS avg_return
+            r.race_id,
+            e.popularity,
+            e.finish_position,
+            e.return_win,
+            e.return_place
         FROM race_entries e
         JOIN races r ON r.race_id = e.race_id
         {where_clause}
-        GROUP BY e.popularity
-        ORDER BY avg_return DESC
+        AND e.finish_position <= 3
+        ORDER BY r.race_id, e.finish_position
     """
 
     with get_connection(db_path) as conn:
@@ -90,21 +106,63 @@ def _fetch_popularity_metrics(
             "Ingest more data or relax the conditions."
         )
 
-    metrics = []
+    combo_stats: Dict[Tuple[int, int, int], Dict[str, float]] = {}
+    total_races = 0
+
+    current_race: Optional[str] = None
+    current_entries: List[Dict[str, float]] = []
+
+    def _flush_race(entries: Iterable[Dict[str, float]]) -> None:
+        nonlocal total_races
+        entries = list(entries)
+        if len(entries) != 3:
+            return
+        popularities = [int(item["popularity"]) for item in entries]
+        if any(pop <= 0 for pop in popularities):
+            return
+        combination = tuple(sorted(popularities))
+        total_races += 1
+
+        total_return = 0.0
+        for item in entries:
+            total_return += float(item["return_place"] or 0.0)
+            if int(item["finish_position"]) == 1:
+                total_return += float(item["return_win"] or 0.0)
+
+        stats = combo_stats.setdefault(
+            combination,
+            {"count": 0.0, "total_return": 0.0, "total_popularity_sum": 0.0},
+        )
+        stats["count"] += 1
+        stats["total_return"] += total_return
+        stats["total_popularity_sum"] += sum(popularities)
+
     for row in rows:
-        avg_return = float(row["avg_return"] or 0.0)
-        metrics.append(
+        race_id = str(row["race_id"])
+        if race_id != current_race:
+            if current_race is not None:
+                _flush_race(current_entries)
+            current_race = race_id
+            current_entries = []
+        current_entries.append(
             {
-                "popularity": int(row["popularity"]),
-                "bets": float(row["bets"]),
-                "races": float(row["races"]),
-                "win_rate": float(row["win_rate"] or 0.0),
-                "avg_return": avg_return,
-                "expected_return_per_100yen": avg_return - 100.0,
+                "popularity": row["popularity"],
+                "finish_position": row["finish_position"],
+                "return_win": row["return_win"],
+                "return_place": row["return_place"],
             }
         )
 
-    return metrics
+    if current_race is not None:
+        _flush_race(current_entries)
+
+    if total_races == 0:
+        raise ValueError(
+            "Historical data does not contain complete trifecta results for the "
+            "given filters."
+        )
+
+    return total_races, combo_stats
 
 
 def recommend_bets(
@@ -120,16 +178,16 @@ def recommend_bets(
     budget: int = 10_000,
     num_tickets: int = 10,
 ) -> List[BetRecommendation]:
-    """Recommend wagers for an upcoming race."""
+    """Recommend 三連複 wagers for an upcoming race."""
 
     if num_tickets <= 0:
         raise ValueError("num_tickets must be positive")
     if budget <= 0:
         raise ValueError("budget must be positive")
-    if len(horse_popularities) < num_tickets:
-        raise ValueError("Provide at least as many horses as tickets you plan to buy")
+    if len(horse_popularities) < 3:
+        raise ValueError("三連複を検討するには最低でも 3 頭の人気順が必要です")
 
-    metrics = _fetch_popularity_metrics(
+    total_races, combo_stats = _fetch_trifecta_statistics(
         db_path,
         racecourse=racecourse,
         distance=distance,
@@ -139,41 +197,46 @@ def recommend_bets(
         weather=weather,
     )
 
-    mean_expected = fmean(m["expected_return_per_100yen"] for m in metrics)
+    candidate_combos = list(combinations(sorted(set(horse_popularities)), 3))
+    if not candidate_combos:
+        raise ValueError("指定された人気順では三連複の組み合わせを作成できません")
+
     ticket_value = budget / num_tickets
 
-    popularity_to_metric = {m["popularity"]: m for m in metrics}
+    if combo_stats:
+        avg_returns = [stats["total_return"] / stats["count"] for stats in combo_stats.values() if stats["count"] > 0]
+        global_avg_return = fmean(avg_returns)
+    else:
+        global_avg_return = 100.0
 
-    upcoming = []
-    for idx, popularity in enumerate(horse_popularities, start=1):
-        metric = popularity_to_metric.get(popularity)
-        if metric is None:
-            expected_bonus = mean_expected
-            avg_return = 100.0 + expected_bonus
+    alpha = 1.0
+    smoothing_denominator = len(candidate_combos)
+
+    recommendations: List[BetRecommendation] = []
+    for combo in candidate_combos:
+        stats = combo_stats.get(combo)
+        hit_count = stats["count"] if stats else 0.0
+        smoothed_hit_rate = (hit_count + alpha) / (total_races + alpha * smoothing_denominator)
+
+        if stats and stats["count"] > 0:
+            avg_payout = stats["total_return"] / stats["count"]
         else:
-            expected_bonus = metric["expected_return_per_100yen"]
-            avg_return = metric["avg_return"]
-        expected_total = (avg_return / 100.0) * ticket_value
-        upcoming.append(
-            {
-                "horse_label": f"Horse #{idx}",
-                "popularity": popularity,
-                "expected": expected_bonus,
-                "expected_total": expected_total,
-            }
+            avg_payout = global_avg_return
+
+        expected_return_multiplier = (avg_payout / 100.0) * smoothed_hit_rate
+        expected_return_per_ticket = ticket_value * expected_return_multiplier
+
+        recommendations.append(
+            BetRecommendation(
+                combination=combo,
+                hit_rate=smoothed_hit_rate,
+                estimated_average_payout=avg_payout,
+                expected_return_per_ticket=expected_return_per_ticket,
+                suggested_bet_amount=ticket_value,
+            )
         )
 
-    ranked = sorted(upcoming, key=lambda item: item["expected"], reverse=True)
+    recommendations.sort(key=lambda rec: rec.expected_return_per_ticket, reverse=True)
 
-    recommendations = [
-        BetRecommendation(
-            horse_label=item["horse_label"],
-            popularity_rank=item["popularity"],
-            expected_return_per_ticket=item["expected_total"],
-            suggested_bet_amount=ticket_value,
-        )
-        for item in ranked[:num_tickets]
-    ]
-
-    return recommendations
+    return recommendations[: min(num_tickets, len(recommendations))]
 

--- a/keiba/cli.py
+++ b/keiba/cli.py
@@ -46,7 +46,13 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Popularity ranks for the upcoming race",
     )
     suggest_parser.add_argument("--budget", type=int, default=10_000, help="Total budget in yen")
-    suggest_parser.add_argument("--num-tickets", dest="num_tickets", type=int, default=10, help="Number of tickets to buy")
+    suggest_parser.add_argument(
+        "--num-tickets",
+        dest="num_tickets",
+        type=int,
+        default=10,
+        help="Number of trifecta tickets to buy",
+    )
     suggest_parser.add_argument("--db-path", type=Path, default=None, help="Path to the SQLite database")
 
     return parser.parse_args(argv)
@@ -88,8 +94,9 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
         for rec in recommendations:
             print(
-                f"{rec.horse_label} (popularity {rec.popularity_rank}): "
-                f"bet {rec.suggested_bet_amount:.0f}円 -> expected return {rec.expected_return_per_ticket:.0f}円"
+                f"Combination {rec.combination_label}: "
+                f"bet {rec.suggested_bet_amount:.0f}円, "
+                f"hit rate {rec.hit_rate * 100:.1f}% -> expected return {rec.expected_return_per_ticket:.0f}円"
             )
         return 0
 


### PR DESCRIPTION
## Summary
- update the recommendation logic to score trifecta combinations from historical hit rates and approximate payouts
- adjust the CLI messaging to print three-horse combinations with hit rate estimates
- document the new workflow and example output for the updated simulation

## Testing
- python -m compileall keiba

------
https://chatgpt.com/codex/tasks/task_e_68e25a4216e883278b71d83a5198d8a5