### PR TITLE
Add track surface input and persist race surface info

### DIFF
--- a/keiba/analysis.py
+++ b/keiba/analysis.py
@@ -32,6 +32,7 @@ def _build_filters(
     racecourse: Optional[str],
     distance: Optional[int],
     track_condition: Optional[str],
+    surface: Optional[str],
     num_runners: Optional[int],
     track_direction: Optional[str],
     weather: Optional[str],
@@ -49,6 +50,7 @@ def _build_filters(
     add("racecourse", racecourse)
     add("distance", distance)
     add("track_condition", track_condition)
+    add("surface", surface)
     add("num_runners", num_runners)
     add("track_direction", track_direction)
     add("weather", weather)
@@ -63,6 +65,7 @@ def _fetch_trifecta_statistics(
     racecourse: Optional[str] = None,
     distance: Optional[int] = None,
     track_condition: Optional[str] = None,
+    surface: Optional[str] = None,
     num_runners: Optional[int] = None,
     track_direction: Optional[str] = None,
     weather: Optional[str] = None,
@@ -80,6 +83,7 @@ def _fetch_trifecta_statistics(
         racecourse=racecourse,
         distance=distance,
         track_condition=track_condition,
+        surface=surface,
         num_runners=num_runners,
         track_direction=track_direction,
         weather=weather,
@@ -174,6 +178,7 @@ def recommend_bets(
     racecourse: Optional[str] = None,
     distance: Optional[int] = None,
     track_condition: Optional[str] = None,
+    surface: Optional[str] = None,
     num_runners: Optional[int] = None,
     track_direction: Optional[str] = None,
     weather: Optional[str] = None,
@@ -192,6 +197,7 @@ def recommend_bets(
         racecourse=racecourse,
         distance=distance,
         track_condition=track_condition,
+        surface=surface,
         num_runners=num_runners,
         track_direction=track_direction,
         weather=weather,

--- a/keiba/cli.py
+++ b/keiba/cli.py
@@ -34,16 +34,16 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     suggest_parser.add_argument("--racecourse", type=str, default=None)
     suggest_parser.add_argument("--distance", type=int, default=None)
     suggest_parser.add_argument("--track-condition", dest="track_condition", type=str, default=None)
+    suggest_parser.add_argument(
+        "--surface",
+        type=str,
+        choices=["turf", "dirt", "芝", "ダート", "unknown"],
+        default=None,
+        help="Track surface (芝 / ダート).",
+    )
     suggest_parser.add_argument("--num-runners", dest="num_runners", type=int, default=None)
     suggest_parser.add_argument("--track-direction", dest="track_direction", type=str, default=None)
     suggest_parser.add_argument("--weather", type=str, default=None)
-    suggest_parser.add_argument(
-        "--race-sex",
-        dest="race_sex",
-        choices=["male", "female", "mixed"],
-        default="mixed",
-        help="Sex restriction for the upcoming race (male / female / mixed)",
-    )
     suggest_parser.add_argument("--budget", type=int, default=10_000, help="Total budget in yen")
     suggest_parser.add_argument(
         "--num-tickets",
@@ -79,15 +79,19 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 0
 
     if args.command == "suggest":
+        surface = args.surface
+        if surface in {"芝", "ダート"}:
+            surface = "turf" if surface == "芝" else "dirt"
+
         recommendations = recommend_bets(
             db_path=args.db_path,
             racecourse=args.racecourse,
             distance=args.distance,
             track_condition=args.track_condition,
+            surface=surface,
             num_runners=args.num_runners,
             track_direction=args.track_direction,
             weather=args.weather,
-            race_sex=args.race_sex,
             budget=args.budget,
             num_tickets=args.num_tickets,
         )

--- a/keiba/database.py
+++ b/keiba/database.py
@@ -45,6 +45,7 @@ def initialize_database(db_path: Path | str | None = None) -> None:
                 racecourse TEXT,
                 distance INTEGER,
                 track_condition TEXT,
+                surface TEXT DEFAULT 'unknown',
                 num_runners INTEGER,
                 track_direction TEXT,
                 weather TEXT,
@@ -78,6 +79,11 @@ def initialize_database(db_path: Path | str | None = None) -> None:
             cursor.execute("ALTER TABLE races ADD COLUMN sex_category TEXT")
             cursor.execute(
                 "UPDATE races SET sex_category = 'mixed' WHERE sex_category IS NULL"
+            )
+        if "surface" not in existing_columns:
+            cursor.execute("ALTER TABLE races ADD COLUMN surface TEXT")
+            cursor.execute(
+                "UPDATE races SET surface = 'unknown' WHERE surface IS NULL"
             )
 
 


### PR DESCRIPTION
## Summary
- allow the CLI to accept芝/ダート track surface input while dropping the race sex requirement
- filter recommendations by surface and persist surface data in the database
- record normalized surface information during data ingestion and migrate existing databases

## Testing
- python -m compileall keiba

------
https://chatgpt.com/codex/tasks/task_e_68e2756d08b88327a49ab7b1966b6180